### PR TITLE
-lv will now show asleep monitors

### DIFF
--- a/brightness.c
+++ b/brightness.c
@@ -88,7 +88,7 @@ int main(int argc, char * const argv[]) {
   CGDirectDisplayID display[kMaxDisplays];
   CGDisplayCount numDisplays;
   CGDisplayErr err;
-  err = CGGetActiveDisplayList(kMaxDisplays, display, &numDisplays);
+  err = CGGetOnlineDisplayList(kMaxDisplays, display, &numDisplays);
   if (err != CGDisplayNoErr)
     errexit("cannot get list of displays (error %d)\n", err);
 


### PR DESCRIPTION
You have code to check CGDisplayIsAsleep but you will never see asleep displays with CGGetActiveDisplayList, so I replaced it with CGGetOnlineDisplayList.
