### PR TITLE
Prepare brightness for homebrew package distribution

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,21 @@
+#!/usr/bin/env make -f
+# Makefile to build brightness
+# Friday November 1, 2013
+# Jon Stacey <jon@jonsview.com>
+
+prefix=/usr/local
+
+build: brightness
+
+brightness: brightness.o
+	$(CC) $(CPPFLAGS) $(CFLAGS) $(ARCH_FLAGS) -framework IOKit -framework ApplicationServices $^ -o $@
+
+%.o: %.c
+	$(CC) $(CPPFLAGS) $(CFLAGS) $(ARCH_FLAGS) $< -c -o $@
+
+clean:
+	rm -f brightness *.o
+
+install:
+	mkdir -p $(prefix)/bin
+	install -s -m 0755 brightness $(prefix)/bin

--- a/README.md
+++ b/README.md
@@ -3,7 +3,25 @@ brightness
 
 Command-line display brightness control for OS X.
 
-These tools control the hardware brightness, where available.  If you can’t use the keyboard keys or Displays System Preferences to control your brightness, `brightness` isn’t going to help you.
+This tool enables programmatic control of OS X screen brightness. You can set and retrieve hardware brightness settings with this utility.
+
+Install with Homebrew
+--------------------
+
+```brew install brightness```
+
+Install From Source
+------------------
+
+```shell
+git clone https://github.com/nriley/brightness.git
+cd brightness
+make
+make install
+```
+
+OS X Version Support
+------------------
 
 Two versions are included.  Both require OS X 10.6 or later — but go back in the history and you’ll find versions that work with older OS X versions.
 
@@ -13,8 +31,15 @@ Two versions are included.  Both require OS X 10.6 or later — but go back in 
 
 Compilation instructions are in comments at the top of each file.
 
-Example
+Usage Examples
 -------
+
+Set 100% brightness: ```brightness 1```
+
+Set 50% brightness: ```brightness 0.5```
+
+Show current settings ```brightness -l```
+
 ````
 % brightness
 usage: brightness [-m|-d display] [-v] <brightness>


### PR DESCRIPTION
This prepares brightness for easier packaging for the [homebrew package manager](http://brew.sh).

- Add Makefile
- Update README to reflect homebrew installation instructions

This is a manual merge of [jmstacey's screenbrightness repo](https://github.com/jmstacey/screenbrightness) into [nriley's brightness upstream repo](https://github.com/nriley/brightness)